### PR TITLE
[#205]Manager can also update the timesheet of employee irrespective of date

### DIFF
--- a/app/controllers/time_sheets_controller.rb
+++ b/app/controllers/time_sheets_controller.rb
@@ -61,7 +61,7 @@ class TimeSheetsController < ApplicationController
     @time_sheet_date = params[:time_sheet_date]
     @time_sheets = @user.time_sheets.where(date: params[:time_sheet_date].to_date)
     if(current_user.is_employee_or_intern? && @time_sheets.last.valid_date_for_update?) ||
-      current_user.is_admin_or_hr?
+      current_user.is_admin_or_hr? || current_user.is_manager?
       return_value, @time_sheets = TimeSheet.update_time_sheet(@time_sheets, timesheet_params)
       unless return_value.include?(false)
         flash[:notice] = 'Timesheet Updated Succesfully'

--- a/spec/controllers/time_sheets_controller_spec.rb
+++ b/spec/controllers/time_sheets_controller_spec.rb
@@ -460,6 +460,7 @@ RSpec.describe TimeSheetsController, type: :controller do
     let!(:user) { FactoryGirl.create(:admin) }
     let!(:project) { FactoryGirl.create(:project) }
     let!(:employee) { FactoryGirl.create(:user) }
+    let!(:manager) { FactoryGirl.create(:manager) }
 
     context 'should successfully update timesheet' do
       it 'if all attributes are valid' do
@@ -500,6 +501,77 @@ RSpec.describe TimeSheetsController, type: :controller do
           to eq('testing API and call with client')
       end
 
+      it 'if timesheet date is less than 7 days' do
+        sign_in user
+        FactoryGirl.create(:user_project,
+          user: user,
+          project: project,
+          start_date: Date.today - 15
+        )
+        time_sheet = FactoryGirl.create(:time_sheet,
+          user: user,
+          project: project,
+          date: Date.today - 1,
+          from_time: "#{Date.today - 1} 10",
+          to_time: "#{Date.today - 1} 11:30"
+        )
+        params = {
+          time_sheets_attributes: {
+            "0" => {
+              project_id: project.id,
+              date: Date.today - 12,
+              from_time: "#{Date.today - 12} 10:00",
+              to_time: "#{Date.today - 12} 11:00",
+              description: 'testing API',
+              id: time_sheet.id
+            }
+          },
+          id:user.id
+        }
+        put :update_timesheet, user_id: user.id,
+          user: params,
+          time_sheet_date: Date.today - 1
+         expect(flash[:notice]).to eq(
+          "Timesheet Updated Succesfully"
+        )
+      end
+
+
+      it 'if timesheet date is less than 7 days for manager' do
+        sign_in manager
+        FactoryGirl.create(:user_project,
+          user: manager,
+          project: project,
+          start_date: Date.today - 15
+        )
+        time_sheet = FactoryGirl.create(:time_sheet,
+          user: user,
+          project: project,
+          date: Date.today - 1,
+          from_time: "#{Date.today - 1} 10",
+          to_time: "#{Date.today - 1} 11:30"
+        )
+        params = {
+          time_sheets_attributes: {
+            "0" => {
+              project_id: project.id,
+              date: Date.today - 12,
+              from_time: "#{Date.today - 12} 10:00",
+              to_time: "#{Date.today - 12} 11:00",
+              description: 'testing API',
+              id: time_sheet.id
+            }
+          },
+          id:user.id
+        }
+        put :update_timesheet, user_id: user.id,
+          user: params,
+          time_sheet_date: Date.today - 1
+         expect(flash[:notice]).to eq(
+          "Timesheet Updated Succesfully"
+        )
+      end
+
       it 'if timesheet date is not less than 2 days in case of Employee' do
         sign_in employee
         FactoryGirl.create(:user_project,
@@ -526,7 +598,7 @@ RSpec.describe TimeSheetsController, type: :controller do
           },
           id:user.id
         }
-        post :update_timesheet, user_id: employee.id,
+        put :update_timesheet, user_id: employee.id,
           user: params,
           time_sheet_date: Date.today - 1
         expect(time_sheet.reload.from_time.to_s).
@@ -561,7 +633,7 @@ RSpec.describe TimeSheetsController, type: :controller do
           },
           id:user.id
         }
-        post :update_timesheet, user_id: user.id,
+        put :update_timesheet, user_id: user.id,
           user: params,
           time_sheet_date: Date.today - 4
         expect(time_sheet.reload.from_time.to_s).
@@ -600,7 +672,7 @@ RSpec.describe TimeSheetsController, type: :controller do
           },
           id:user.id
         }
-        post :update_timesheet, user_id: user.id,
+        put :update_timesheet, user_id: user.id,
           user: params,
           time_sheet_date: Date.today - 1
         assigns(:time_sheets)[0].errors.full_messages ==
@@ -635,7 +707,7 @@ RSpec.describe TimeSheetsController, type: :controller do
           },
           id:user.id
         }
-        post :update_timesheet, user_id: user.id,
+        put :update_timesheet, user_id: user.id,
           user: params,
           time_sheet_date: Date.today - 1
         assigns(:time_sheets)[0].errors.full_messages ==
@@ -671,47 +743,13 @@ RSpec.describe TimeSheetsController, type: :controller do
           },
           id:user.id
         }
-        post :update_timesheet, user_id: user.id,
+        put :update_timesheet, user_id: user.id,
           user: params,
           time_sheet_date: Date.today - 1
         assigns(:time_sheets)[0].errors.full_messages ==
           ["To time Invalid time format. Format should be HH:MM"]
         expect(time_sheet.reload.to_time).
           to eq(Time.parse("#{Date.today - 1} 11:30"))
-        should render_template(:edit_timesheet)
-      end
-
-      it 'if timesheet date is less than 7 days' do
-        sign_in user
-        FactoryGirl.create(:user_project,
-          user: user,
-          project: project,
-          start_date: Date.today - 15
-        )
-        time_sheet = FactoryGirl.create(:time_sheet,
-          user: user,
-          project: project,
-          date: Date.today - 1,
-          from_time: "#{Date.today - 1} 10",
-          to_time: "#{Date.today - 1} 11:30"
-        )
-        params = {
-          time_sheets_attributes: {
-            "0" => {
-              project_id: project.id,
-              date: Date.today - 12,
-              from_time: "#{Date.today - 12} 10:00",
-              to_time: "#{Date.today - 12} 11:00",
-              description: 'testing API',
-              id: time_sheet.id
-            }
-          },
-          id:user.id
-        }
-        post :update_timesheet, user_id: user.id,
-          user: params,
-          time_sheet_date: Date.today - 1
-        expect(time_sheet.reload.date).to eq(Date.today - 1)
         should render_template(:edit_timesheet)
       end
 
@@ -743,7 +781,7 @@ RSpec.describe TimeSheetsController, type: :controller do
           },
           id:user.id
         }
-        post :update_timesheet, user_id: employee.id,
+        put :update_timesheet, user_id: employee.id,
           user: params,
           time_sheet_date: Date.today - 9
         expect(time_sheet.reload.from_time).


### PR DESCRIPTION
Earlier only admin and Hr was able to update timesheet if timesheet was older than 7 days, Now manager will also able to update timesheet if timesheet is older than 7 days.